### PR TITLE
Update websockets version range in requirements.txt

### DIFF
--- a/central_system.py
+++ b/central_system.py
@@ -3,8 +3,6 @@
 import asyncio
 import logging
 
-import websockets.asyncio
-import websockets.asyncio.server
 from central_systems.central_system_v16 import ChargePoint16
 from central_systems.central_system_v201 import ChargePoint201
 import http

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ocpp
 cryptography
 pydantic==1.*
-websockets
+websockets>=10, < 14


### PR DESCRIPTION
Specified the version range for websockets in `requirements.txt` to be ">=10, <14" to ensure compatibility with the current CSMS implementation. I encountered issues with websockets version 14 and, while unable to fix the code for that version, limiting the version solves the problem.

Additionally, I removed imports of websockets.asyncio, as they were not being used and restricted the websockets version to 13.