### PR TITLE
Change the git clone protocol, from SSH to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Josev"]
 	path = Josev
-	url = git@github.com:EVerest/ext-switchev-iso15118.git
+	url = https://github.com/EVerest/ext-switchev-iso15118.git
 	branch = everest

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ The CSMS will respond "friendly" to most OCPP messages initiated by the Chargepo
 
 # Usage
 
-In this project [Josev](https://github.com/EVerest/ext-switchev-iso15118) is needed as git submodule to generate the CertificateInstallationResponse. To clone Josev as well, execute these commands after cloning this repo:
+In this project, [Josev](https://github.com/EVerest/ext-switchev-iso15118) is needed as git submodule to generate the CertificateInstallationResponse. To clone both this repo and the Josev submodule, execute this command:
 
 ```bash
-git clone --recurse-submodules git@github.com:EVerest/ocpp-csms.git
+git clone --recurse-submodules https://github.com/EVerest/ocpp-csms.git
 ```
 
 Install the necessary python packages using


### PR DESCRIPTION
Change the git clone protocol, from SSH to HTTPS

The change from SSH to HTTPS allows users to clone the repository even if they don't have an SSH key associated with their GitHub account.

Points changed:
  - Updated the Josev submodule URL to use HTTPS
  - Revised cloning instructions in README.md